### PR TITLE
Add default export for useSt8

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Warning: Hooks are currently a React [RFC](https://github.com/reactjs/rfcs/pull
 ```javascript
 import * as React from "react";
 import { render } from "react-dom";
-import { useSt8 } from "use-st8";
+import { useSt8 } from "use-st8"; // (or) import useSt8 from 'use-st8';
 
 function App() {
   const count = useSt8(0);
@@ -115,6 +115,13 @@ _[sarcasm]Which saves a whooping 21 characters. Now go forth and refactoring all
 # The name
 
 _useSt8_ is a shorter form of _useState_, which has _8_ characters. Also, the pronounciation is pretty similar to "useState".
+
+If you prefer to use with a different name, the `useSt8` named export is set as the default export as well.
+
+```javascript
+import useSt8 from 'use-st8';
+import useCustomNameSt8 from 'use-st8';
+```
 
 # Cool?
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,3 +14,5 @@ export function useSt8<T>(initial: (() => T) | T): {
 } {
     return st8.bind(useState(initial))
 }
+
+export default useSt8


### PR DESCRIPTION
Nice work! I really like the consolidated approach to `useState`.
Thank you for this 🎉 

Just opening this to see if you would consider adding a default export to allow users a way to name the function whatever they'd like vs aliasing the named export.

