### PR TITLE
feat: memoize function hook returns

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,22 @@
-import { useState } from "react"
+import { useMemo, useState } from "react";
 
-function st8() {
-    switch(arguments.length) {
-        case 0: return this[0]
-        case 1: return void this[1](arguments[0])
-        default: throw new Error("Expected 0 or 1 arguments")
-    }
+export type St8<V> = {
+  (): V;
+  (newValue: V | ((current: V) => V)): void;
+};
+
+export function useSt8<V>(initialValue: (() => V) | V): St8<V> {
+  const [state, setState] = useState(initialValue);
+  return useMemo(() => {
+    return function st8() {
+      switch (arguments.length) {
+        case 0:
+          return state;
+        case 1:
+          return void setState(arguments[0]);
+        default:
+          throw new Error("Expected 0 or 1 arguments");
+      }
+    } as St8<V>;
+  }, [state]);
 }
-
-export type St8<T> = {
-    (): T
-    (newValue: T | ((current: T) => T)): void
-}
-
-export function useSt8<T>(initial: (() => T) | T): St8<T> {
-    return st8.bind(useState(initial))
-}
-
-export default useSt8


### PR DESCRIPTION
First of all — thanks for the clever idea @mweststrate! 

Patch implements memoization for the returned function: creation of new function (and, accordingly, a new memory reference) only depends on internal state change and not from props outside of hook. This allows to avoid unnecessary rerenders of dependant react components.